### PR TITLE
Chức năng in hoá đơn sau khi người dùng thanh toán, chuyển hướng khi huỷ thanh toán 

### DIFF
--- a/Webike/src/main/java/vn/edu/hcmuaf/fit/webike/controllers/payment/Pay.java
+++ b/Webike/src/main/java/vn/edu/hcmuaf/fit/webike/controllers/payment/Pay.java
@@ -79,6 +79,7 @@ public class Pay extends HttpServlet {
         }else if (responseCode.equalsIgnoreCase("09") || responseCode.equalsIgnoreCase("24")) {
             status = "Đã hủy";
             oid = dao.insertOrder(phoneNum,0, 0, "", null, null,null, status, accountID, shopID);
+            request.getSession().setAttribute("cancelMessage", "Bạn đã hủy thanh toán!");
         }
 
         request.setAttribute("orderItem", order.getData());
@@ -100,10 +101,8 @@ public class Pay extends HttpServlet {
                 request.getRequestDispatcher("GKY/billing.jsp").forward(request, response);
                 break;
             case "09":
-                request.getRequestDispatcher("GKY/paymentCanceled.jsp").forward(request, response);
-                break;
             case "24":
-                request.getRequestDispatcher("GKY/paymentCanceled.jsp").forward(request, response);
+                response.sendRedirect(request.getContextPath() + "/list-products");
                 break;
         }
     }

--- a/Webike/src/main/webapp/GKY/assets/css/billing.css
+++ b/Webike/src/main/webapp/GKY/assets/css/billing.css
@@ -5,6 +5,8 @@
 }
 
 .billing-card {
+    /*height: auto !important;*/
+    /*overflow: visible !important;*/
     background-color: var(--white-color);
     border-radius: 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);

--- a/Webike/src/main/webapp/GKY/assets/css/billing.css
+++ b/Webike/src/main/webapp/GKY/assets/css/billing.css
@@ -5,13 +5,11 @@
 }
 
 .billing-card {
-    /*height: auto !important;*/
-    /*overflow: visible !important;*/
     background-color: var(--white-color);
     border-radius: 8px;
     box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
     padding: 30px;
-    max-width: 800px;
+    max-width: 1000px;
     margin: 0 auto;
 }
 
@@ -80,8 +78,9 @@
 
 .order-item__img {
     width: 125px;
-    height: 80px;
-    object-fit: cover;
+    height: auto;
+    max-height: 100px;
+    object-fit: contain;
     border-radius: 4px;
     margin-right: 20px;
 }
@@ -215,8 +214,6 @@
     background-color: #cfcfcf;
     border-color: #c2c2c2;
 }
-
-
 
 @media (max-width: 768px) {
     .billing-info {

--- a/Webike/src/main/webapp/GKY/assets/css/billing.css
+++ b/Webike/src/main/webapp/GKY/assets/css/billing.css
@@ -105,6 +105,117 @@
     color: #555;
 }
 
+/*In hoa don*/
+.billing-button {
+    display: flex;
+    justify-content: center;
+    margin-top: 20px;
+}
+
+.billing-button .print-invoice {
+    padding: 10px 20px;
+    font-size: 1.6rem;
+    font-weight: 500;
+    color: var(--white-color);
+    background-color: var(--primary-color);
+    border: none;
+    border-radius: 4px;
+    cursor: pointer;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.billing-button .print-invoice:hover {
+    background-color: #d43f1d; /* Slightly darker shade for hover */
+    transform: scale(1.05);
+}
+
+.billing-button .print-invoice:active {
+    transform: scale(0.95);
+}
+
+.modal-content {
+    border-radius: 12px;
+    box-shadow: 0 4px 15px rgba(0, 0, 0, 0.2);
+    overflow: hidden;
+}
+
+.modal-header {
+    background-color: var(--primary-color);
+    color: var(--white-color);
+    padding: 15px 20px;
+    border-bottom: 1px solid var(--border-color);
+}
+
+.modal-header .modal-title {
+    font-size: 1.8rem;
+    font-weight: 700;
+}
+
+.modal-header .btn-close {
+    background: none;
+    border: none;
+    font-size: 1.4rem;
+    color: var(--white-color);
+    opacity: 0.8;
+    transition: opacity 0.3s ease;
+}
+
+.modal-header .btn-close:hover {
+    opacity: 1;
+}
+
+.modal-body {
+    padding: 20px;
+    font-size: 1.4rem;
+    color: var(--text-color);
+    background-color: #f9f9f9;
+}
+
+.modal-body .form-check {
+    margin-bottom: 15px;
+    font-size: 1.4rem;
+}
+
+.modal-footer {
+    padding: 15px 20px;
+    background-color: #f1f1f1;
+    border-top: 1px solid var(--border-color);
+    display: flex;
+    justify-content: flex-end;
+    gap: 10px;
+}
+
+.modal-footer .btn-primary {
+    background-color: var(--primary-color);
+    border-color: var(--primary-color);
+    color: var(--white-color);
+    font-size: 1.5rem;
+    border-radius: 4px;
+    transition: background-color 0.3s ease, transform 0.2s ease;
+}
+
+.modal-footer .btn-primary:hover {
+    background-color: #d43f1d;
+    border-color: #d43f1d;
+    transform: scale(1.05);
+}
+
+.modal-footer .btn-secondary {
+    background-color: #e0e0e0;
+    border-color: #d6d6d6;
+    color: var(--text-color);
+    font-size: 1.5rem;
+    border-radius: 4px;
+    transition: background-color 0.3s ease;
+}
+
+.modal-footer .btn-secondary:hover {
+    background-color: #cfcfcf;
+    border-color: #c2c2c2;
+}
+
+
+
 @media (max-width: 768px) {
     .billing-info {
         grid-template-columns: 1fr;

--- a/Webike/src/main/webapp/GKY/assets/js/printBill.js
+++ b/Webike/src/main/webapp/GKY/assets/js/printBill.js
@@ -1,0 +1,162 @@
+document.addEventListener("DOMContentLoaded", function () {
+    const confirmBtn = document.getElementById("confirmDownload");
+    if (confirmBtn) {
+        confirmBtn.addEventListener("click", async function () {
+            try {
+                const selectedInput = document.querySelector('input[name="format"]:checked');
+                if (!selectedInput) {
+                    alert("Vui lòng chọn định dạng trước khi xác nhận.");
+                    return;
+                }
+                const selectedFormat = selectedInput.value;
+                const billingCard = document.querySelector(".billing-card");
+                const billingContainer = document.querySelector(".billing-container");
+                const appContainer = document.querySelector(".app");
+
+                if (!billingCard) {
+                    alert("Không tìm thấy thông tin hóa đơn.");
+                    return;
+                }
+
+                // Đảm bảo tất cả hình ảnh được tải trước khi chụp
+                await Promise.all(Array.from(billingCard.querySelectorAll('img')).map(img => {
+                    if (!img.complete) {
+                        return new Promise(resolve => {
+                            img.onload = img.onerror = resolve;
+                        });
+                    }
+                    return Promise.resolve();
+                }));
+
+                // Lưu trữ kiểu dáng gốc
+                const originalStyles = {
+                    billingCard: {
+                        height: billingCard.style.height,
+                        overflow: billingCard.style.overflow,
+                        position: billingCard.style.position,
+                        width: billingCard.style.width,
+                        maxWidth: billingCard.style.maxWidth,
+                        margin: billingCard.style.margin,
+                        top: billingCard.style.top
+                    },
+                    billingContainer: {
+                        overflow: billingContainer.style.overflow,
+                        minHeight: billingContainer.style.minHeight
+                    },
+                    appContainer: {
+                        overflow: appContainer.style.overflow
+                    }
+                };
+
+                // Tạm thời điều chỉnh kiểu dáng để chụp toàn bộ nội dung
+                billingCard.style.height = 'auto';
+                billingCard.style.overflow = 'visible';
+                billingCard.style.position = 'absolute';
+                billingCard.style.width = '1000px';
+                billingCard.style.maxWidth = 'none';
+                billingCard.style.margin = '0';
+                billingCard.style.top = '0'; // Đảm bảo không bị đẩy xuống
+
+                billingContainer.style.overflow = 'visible';
+                billingContainer.style.minHeight = 'auto';
+
+                appContainer.style.overflow = 'visible'; // Đảm bảo lớp cha không giới hạn
+
+                // Ẩn các phần tử không cần thiết
+                const overlay = document.querySelector('.modal__overlay');
+                const modal = document.querySelector('.modal');
+                const billingButton = document.querySelector('.billing-button');
+                if (overlay) overlay.style.display = 'none';
+                if (modal) modal.style.display = 'none';
+                if (billingButton) billingButton.style.display = 'none'; // Ẩn nút "In hóa đơn" trong ảnh chụp
+
+                // Debug kích thước
+                console.log("Kích thước billing-card trước khi chụp:", billingCard.getBoundingClientRect());
+
+                // Chụp ảnh
+                let dataUrl;
+                if (selectedFormat === "png" || selectedFormat === "jpg") {
+                    dataUrl = await domtoimage.toJpeg(billingCard, {
+                        quality: 1,
+                        scale: 2,
+                        bgcolor: '#fff',
+                        style: {
+                            'transform': 'none',
+                            'left': '0',
+                            'top': '0'
+                        }
+                    });
+                    const link = document.createElement("a");
+                    link.download = `hoa_don_${Date.now()}.png`;
+                    link.href = dataUrl;
+                    link.click();
+                } else if (selectedFormat === "pdf") {
+                    dataUrl = await domtoimage.toPng(billingCard, {
+                        quality: 1,
+                        scale: 2,
+                        bgcolor: '#fff',
+                        style: {
+                            'transform': 'none',
+                            'left': '0',
+                            'top': '0'
+                        }
+                    });
+                    const { jsPDF } = window.jspdf;
+                    const pdf = new jsPDF({ orientation: 'portrait', unit: 'mm', format: 'a4' });
+                    const imgProps = pdf.getImageProperties(dataUrl);
+                    const pdfWidth = pdf.internal.pageSize.getWidth();
+                    const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+
+                    if (pdfHeight > pdf.internal.pageSize.getHeight()) {
+                        const ratio = pdf.internal.pageSize.getHeight() / pdfHeight;
+                        pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, pdfHeight * ratio);
+                    } else {
+                        pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, pdfHeight);
+                    }
+                    pdf.save(`hoa_don_${Date.now()}.pdf`);
+                }
+
+                // Khôi phục kiểu dáng gốc
+                Object.assign(billingCard.style, originalStyles.billingCard);
+                Object.assign(billingContainer.style, originalStyles.billingContainer);
+                Object.assign(appContainer.style, originalStyles.appContainer);
+                if (overlay) overlay.style.display = '';
+                if (modal) modal.style.display = '';
+                if (billingButton) billingButton.style.display = '';
+
+                // Đóng modal bằng API của Bootstrap
+                const modalElement = document.getElementById('printModal');
+                const bootstrapModal = bootstrap.Modal.getInstance(modalElement);
+                if (bootstrapModal) {
+                    bootstrapModal.hide();
+                }
+
+            } catch (error) {
+                alert("Có lỗi xảy ra khi tạo file. Vui lòng thử lại.\nChi tiết lỗi: " + error.message);
+                console.error(error);
+
+                // Đảm bảo khôi phục kiểu dáng ngay cả khi có lỗi
+                const billingCard = document.querySelector(".billing-card");
+                const billingContainer = document.querySelector(".billing-container");
+                const appContainer = document.querySelector(".app");
+                const overlay = document.querySelector('.modal__overlay');
+                const modal = document.querySelector('.modal');
+                const billingButton = document.querySelector('.billing-button');
+
+                Object.assign(billingCard.style, originalStyles.billingCard);
+                Object.assign(billingContainer.style, originalStyles.billingContainer);
+                Object.assign(appContainer.style, originalStyles.appContainer);
+                if (overlay) overlay.style.display = '';
+                if (modal) modal.style.display = '';
+                if (billingButton) billingButton.style.display = '';
+
+                // Đóng modal trong trường hợp lỗi
+                const modalElement = document.getElementById('printModal');
+                const bootstrapModal = bootstrap.Modal.getInstance(modalElement);
+                if (bootstrapModal) {
+                    bootstrapModal.hide();
+                }
+            }
+        });
+    }
+});

--- a/Webike/src/main/webapp/GKY/billing.jsp
+++ b/Webike/src/main/webapp/GKY/billing.jsp
@@ -23,6 +23,24 @@
           integrity="sha384-4Q6Gf2aSP4eDXB8Miphtr37CMZZQ5oXLH2yaXMJ2w8e2ZtHTl7GptT4jmndRuHDT" crossorigin="anonymous">
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/toastify-js/src/toastify.min.css"/>
     <title>Thông tin đơn thanh toán</title>
+    <style media="print">
+        body * {
+            visibility: hidden;
+        }
+
+        .billing-card, .billing-card * {
+            visibility: visible;
+        }
+
+        .billing-card {
+            position: absolute;
+            left: 0;
+            top: 0;
+            width: 100%;
+            background: white;
+            box-shadow: none;
+        }
+    </style>
 </head>
 <body>
 <div class="app">
@@ -141,157 +159,17 @@
 <%--<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>--%>
 <script src="https://cdn.jsdelivr.net/npm/dom-to-image-more@2.8/dist/dom-to-image-more.min.js"></script>
 <script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
-
-<%--<script>--%>
-<%--    document.getElementById('confirmPrint').addEventListener('click', function () {--%>
-<%--        const format = document.querySelector('input[name="printFormat"]:checked').value;--%>
-<%--        const billingCard = document.querySelector('.billing-card');--%>
-
-<%--        // Thêm kiểm tra xem html2canvas và jsPDF có được tải không--%>
-<%--        if (typeof html2canvas === 'undefined') {--%>
-<%--            alert('Lỗi: Thư viện html2canvas không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.');--%>
-<%--            return;--%>
-<%--        }--%>
-<%--        if (typeof window.jspdf === 'undefined') {--%>
-<%--            alert('Lỗi: Thư viện jsPDF không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.');--%>
-<%--            return;--%>
-<%--        }--%>
-
-<%--        // Fix tạm thời: tránh lỗi `oklch` nếu có--%>
-<%--        billingCard.querySelectorAll("*").forEach(el => {--%>
-<%--            const style = getComputedStyle(el);--%>
-<%--            if (style.color.includes("oklch")) {--%>
-<%--                el.style.color = "#000"; // fallback--%>
-<%--            }--%>
-<%--            if (style.backgroundColor.includes("oklch")) {--%>
-<%--                el.style.backgroundColor = "#fff"; // fallback--%>
-<%--            }--%>
-<%--        });--%>
-
-<%--        // Đảm bảo nội dung hiển thị đầy đủ trước khi chụp--%>
-<%--        billingCard.style.height = 'auto';--%>
-<%--        billingCard.style.overflow = 'visible';--%>
-
-<%--        // Tùy chọn cho html2canvas--%>
-<%--        const options = {--%>
-<%--            scale: 2, // Tăng độ phân giải--%>
-<%--            useCORS: true, // Cho phép tải hình ảnh từ URL khác--%>
-<%--            allowTaint: true, // Cho phép xử lý hình ảnh bị tainted--%>
-<%--            logging: true // Bật logging để debug--%>
-<%--        };--%>
-
-<%--        // Chụp .billing-card cho cả hai định dạng--%>
-<%--        html2canvas(billingCard, options).then(canvas => {--%>
-<%--            console.log('Canvas được tạo thành công:', canvas);--%>
-
-<%--            if (format === 'png') {--%>
-<%--                const imgData = canvas.toDataURL('image/png');--%>
-<%--                const link = document.createElement('a');--%>
-<%--                link.download = 'hoa_don_' + Date.now() + '.png';--%>
-<%--                link.href = imgData;--%>
-<%--                link.click();--%>
-<%--            } else if (format === 'pdf') {--%>
-<%--                const { jsPDF } = window.jspdf;--%>
-<%--                const doc = new jsPDF({--%>
-<%--                    orientation: 'portrait',--%>
-<%--                    unit: 'mm',--%>
-<%--                    format: 'a4'--%>
-<%--                });--%>
-
-<%--                const imgData = canvas.toDataURL('image/png');--%>
-<%--                const imgProps = doc.getImageProperties(imgData);--%>
-<%--                const pdfWidth = doc.internal.pageSize.getWidth();--%>
-<%--                const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;--%>
-<%--                doc.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);--%>
-<%--                doc.save('hoa_don_' + Date.now() + '.pdf');--%>
-<%--            }--%>
-<%--        }).catch(err => {--%>
-<%--            console.error('Lỗi khi tạo file:', err);--%>
-<%--            alert('Có lỗi xảy ra khi tạo file. Vui lòng thử lại. Chi tiết lỗi: ' + err.message);--%>
-<%--        });--%>
-
-<%--        // Đóng modal--%>
-<%--        bootstrap.Modal.getInstance(document.getElementById('printModal')).hide();--%>
-<%--    });--%>
-<%--</script>--%>
+<script src="${pageContext.request.contextPath}/GKY/assets/js/printBill.js"></script>
 <script>
-    window.onload = function () {
-        const confirmBtn = document.getElementById("confirmDownload");
-        if (confirmBtn) {
-            confirmBtn.addEventListener("click", async function () {
-                try {
-                    // Kiểm tra xem domtoimage có tồn tại không
-                    if (typeof domtoimage === 'undefined') {
-                        alert("Lỗi: Thư viện domtoimage không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.");
-                        return;
-                    }
-
-                    const selectedInput = document.querySelector('input[name="format"]:checked');
-                    if (!selectedInput) {
-                        alert("Vui lòng chọn định dạng trước khi xác nhận.");
-                        return;
-                    }
-                    const selectedFormat = selectedInput.value;
-                    const billingCard = document.querySelector(".billing-card");
-
-                    if (!billingCard) {
-                        alert("Không tìm thấy thông tin hóa đơn.");
-                        return;
-                    }
-
-                    // Đảm bảo nội dung hiển thị đầy đủ trước khi chụp
-                    const originalHeight = billingCard.style.height;
-                    const originalOverflow = billingCard.style.overflow;
-                    billingCard.style.height = 'auto'; // Bỏ giới hạn chiều cao
-                    billingCard.style.overflow = 'visible'; // Hiển thị toàn bộ nội dung
-
-                    if (selectedFormat === "png" || selectedFormat === "jpg") {
-                        const dataUrl = await domtoimage.toJpeg(billingCard, {
-                            quality: 1, // Chất lượng tối đa (0-1)
-                            scale: 2 // Tăng độ phân giải gấp 2 lần
-                        });
-                        const link = document.createElement("a");
-                        link.download = `hoa_don_${Date.now()}.${selectedFormat}`;
-                        link.href = dataUrl;
-                        link.click();
-                    } else if (selectedFormat === "pdf") {
-                        const dataUrl = await domtoimage.toPng(billingCard, {
-                            quality: 1, // Chất lượng tối đa
-                            scale: 2 // Tăng độ phân giải
-                        });
-                        const { jsPDF } = window.jspdf;
-                        const pdf = new jsPDF({
-                            orientation: 'portrait',
-                            unit: 'mm',
-                            format: 'a4'
-                        });
-                        const imgProps = pdf.getImageProperties(dataUrl);
-                        const pdfWidth = pdf.internal.pageSize.getWidth();
-                        const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
-
-                        // Nếu nội dung quá dài, chia thành nhiều trang
-                        if (pdfHeight > pdf.internal.pageSize.getHeight()) {
-                            const ratio = pdf.internal.pageSize.getHeight() / pdfHeight;
-                            const adjustedHeight = pdfHeight * ratio;
-                            pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, adjustedHeight);
-                        } else {
-                            pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, pdfHeight);
-                        }
-                        pdf.save(`hoa_don_${Date.now()}.pdf`);
-                    }
-
-                    // Khôi phục lại style ban đầu
-                    billingCard.style.height = originalHeight;
-                    billingCard.style.overflow = originalOverflow;
-                } catch (error) {
-                    alert("Có lỗi xảy ra khi tạo file. Vui lòng thử lại.\nChi tiết lỗi: " + error.message);
-                    console.error(error);
-                }
-            });
-        }
+    window.billingData = {
+        deposit: "${sessionScope.deposit}",
+        remain: "${sessionScope.remain}",
+        depositDate: "${sessionScope.order.depositDate}",
+        appointment: "<%=request.getSession().getAttribute("appointment")%>",
+        shopAddress: "${shopAddress}",
+        userName: "${userName}",
+        phoneNum: "${phoneNum}"
     };
 </script>
-
-
 </body>
 </html>

--- a/Webike/src/main/webapp/GKY/billing.jsp
+++ b/Webike/src/main/webapp/GKY/billing.jsp
@@ -100,6 +100,36 @@
                 </c:forEach>
             </div>
         </div>
+        <%-- Button in hoa don --%>
+        <div class="billing-button">
+            <button class="print-invoice" data-bs-toggle="modal" data-bs-target="#printModal">In hóa đơn</button>
+        </div>
+    </div>
+
+    <!-- Modal -->
+    <div class="modal fade" id="printModal" tabindex="-1" aria-labelledby="printModalLabel" aria-hidden="true">
+        <div class="modal-dialog">
+            <div class="modal-content">
+                <div class="modal-header">
+                    <h5 class="modal-title" id="printModalLabel">Chọn định dạng in</h5>
+                    <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
+                </div>
+                <div class="modal-body">
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="printFormat" id="pngFormat" value="png" checked>
+                        <label class="form-check-label" for="pngFormat">PNG</label>
+                    </div>
+                    <div class="form-check">
+                        <input class="form-check-input" type="radio" name="printFormat" id="pdfFormat" value="pdf">
+                        <label class="form-check-label" for="pdfFormat">PDF</label>
+                    </div>
+                </div>
+                <div class="modal-footer">
+                    <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
+                    <button type="button" class="btn btn-primary" id="confirmPrint">Xác nhận</button>
+                </div>
+            </div>
+        </div>
     </div>
 
     <jsp:include page="/GKY/footer.jsp"/>
@@ -108,5 +138,9 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
         crossorigin="anonymous"></script>
+
+
+
+
 </body>
 </html>

--- a/Webike/src/main/webapp/GKY/billing.jsp
+++ b/Webike/src/main/webapp/GKY/billing.jsp
@@ -116,17 +116,17 @@
                 </div>
                 <div class="modal-body">
                     <div class="form-check">
-                        <input class="form-check-input" type="radio" name="printFormat" id="pngFormat" value="png" checked>
+                        <input class="form-check-input" type="radio" name="format" id="pngFormat" value="png" checked>
                         <label class="form-check-label" for="pngFormat">PNG</label>
                     </div>
                     <div class="form-check">
-                        <input class="form-check-input" type="radio" name="printFormat" id="pdfFormat" value="pdf">
+                        <input class="form-check-input" type="radio" name="format" id="pdfFormat" value="pdf">
                         <label class="form-check-label" for="pdfFormat">PDF</label>
                     </div>
                 </div>
                 <div class="modal-footer">
                     <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Hủy</button>
-                    <button type="button" class="btn btn-primary" id="confirmPrint">Xác nhận</button>
+                    <button type="button" class="btn btn-primary" id="confirmDownload">Xác nhận</button>
                 </div>
             </div>
         </div>
@@ -138,8 +138,159 @@
 <script src="https://cdn.jsdelivr.net/npm/bootstrap@5.3.6/dist/js/bootstrap.bundle.min.js"
         integrity="sha384-j1CDi7MgGQ12Z7Qab0qlWQ/Qqz24Gc6BM0thvEMVjHnfYGF0rmFCozFSxQBxwHKO"
         crossorigin="anonymous"></script>
+<%--<script src="https://cdn.jsdelivr.net/npm/html2canvas@1.4.1/dist/html2canvas.min.js"></script>--%>
+<script src="https://cdn.jsdelivr.net/npm/dom-to-image-more@2.8/dist/dom-to-image-more.min.js"></script>
+<script src="https://cdnjs.cloudflare.com/ajax/libs/jspdf/2.5.1/jspdf.umd.min.js"></script>
 
+<%--<script>--%>
+<%--    document.getElementById('confirmPrint').addEventListener('click', function () {--%>
+<%--        const format = document.querySelector('input[name="printFormat"]:checked').value;--%>
+<%--        const billingCard = document.querySelector('.billing-card');--%>
 
+<%--        // Thêm kiểm tra xem html2canvas và jsPDF có được tải không--%>
+<%--        if (typeof html2canvas === 'undefined') {--%>
+<%--            alert('Lỗi: Thư viện html2canvas không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.');--%>
+<%--            return;--%>
+<%--        }--%>
+<%--        if (typeof window.jspdf === 'undefined') {--%>
+<%--            alert('Lỗi: Thư viện jsPDF không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.');--%>
+<%--            return;--%>
+<%--        }--%>
+
+<%--        // Fix tạm thời: tránh lỗi `oklch` nếu có--%>
+<%--        billingCard.querySelectorAll("*").forEach(el => {--%>
+<%--            const style = getComputedStyle(el);--%>
+<%--            if (style.color.includes("oklch")) {--%>
+<%--                el.style.color = "#000"; // fallback--%>
+<%--            }--%>
+<%--            if (style.backgroundColor.includes("oklch")) {--%>
+<%--                el.style.backgroundColor = "#fff"; // fallback--%>
+<%--            }--%>
+<%--        });--%>
+
+<%--        // Đảm bảo nội dung hiển thị đầy đủ trước khi chụp--%>
+<%--        billingCard.style.height = 'auto';--%>
+<%--        billingCard.style.overflow = 'visible';--%>
+
+<%--        // Tùy chọn cho html2canvas--%>
+<%--        const options = {--%>
+<%--            scale: 2, // Tăng độ phân giải--%>
+<%--            useCORS: true, // Cho phép tải hình ảnh từ URL khác--%>
+<%--            allowTaint: true, // Cho phép xử lý hình ảnh bị tainted--%>
+<%--            logging: true // Bật logging để debug--%>
+<%--        };--%>
+
+<%--        // Chụp .billing-card cho cả hai định dạng--%>
+<%--        html2canvas(billingCard, options).then(canvas => {--%>
+<%--            console.log('Canvas được tạo thành công:', canvas);--%>
+
+<%--            if (format === 'png') {--%>
+<%--                const imgData = canvas.toDataURL('image/png');--%>
+<%--                const link = document.createElement('a');--%>
+<%--                link.download = 'hoa_don_' + Date.now() + '.png';--%>
+<%--                link.href = imgData;--%>
+<%--                link.click();--%>
+<%--            } else if (format === 'pdf') {--%>
+<%--                const { jsPDF } = window.jspdf;--%>
+<%--                const doc = new jsPDF({--%>
+<%--                    orientation: 'portrait',--%>
+<%--                    unit: 'mm',--%>
+<%--                    format: 'a4'--%>
+<%--                });--%>
+
+<%--                const imgData = canvas.toDataURL('image/png');--%>
+<%--                const imgProps = doc.getImageProperties(imgData);--%>
+<%--                const pdfWidth = doc.internal.pageSize.getWidth();--%>
+<%--                const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;--%>
+<%--                doc.addImage(imgData, 'PNG', 0, 0, pdfWidth, pdfHeight);--%>
+<%--                doc.save('hoa_don_' + Date.now() + '.pdf');--%>
+<%--            }--%>
+<%--        }).catch(err => {--%>
+<%--            console.error('Lỗi khi tạo file:', err);--%>
+<%--            alert('Có lỗi xảy ra khi tạo file. Vui lòng thử lại. Chi tiết lỗi: ' + err.message);--%>
+<%--        });--%>
+
+<%--        // Đóng modal--%>
+<%--        bootstrap.Modal.getInstance(document.getElementById('printModal')).hide();--%>
+<%--    });--%>
+<%--</script>--%>
+<script>
+    window.onload = function () {
+        const confirmBtn = document.getElementById("confirmDownload");
+        if (confirmBtn) {
+            confirmBtn.addEventListener("click", async function () {
+                try {
+                    // Kiểm tra xem domtoimage có tồn tại không
+                    if (typeof domtoimage === 'undefined') {
+                        alert("Lỗi: Thư viện domtoimage không được tải. Vui lòng kiểm tra kết nối hoặc thử lại.");
+                        return;
+                    }
+
+                    const selectedInput = document.querySelector('input[name="format"]:checked');
+                    if (!selectedInput) {
+                        alert("Vui lòng chọn định dạng trước khi xác nhận.");
+                        return;
+                    }
+                    const selectedFormat = selectedInput.value;
+                    const billingCard = document.querySelector(".billing-card");
+
+                    if (!billingCard) {
+                        alert("Không tìm thấy thông tin hóa đơn.");
+                        return;
+                    }
+
+                    // Đảm bảo nội dung hiển thị đầy đủ trước khi chụp
+                    const originalHeight = billingCard.style.height;
+                    const originalOverflow = billingCard.style.overflow;
+                    billingCard.style.height = 'auto'; // Bỏ giới hạn chiều cao
+                    billingCard.style.overflow = 'visible'; // Hiển thị toàn bộ nội dung
+
+                    if (selectedFormat === "png" || selectedFormat === "jpg") {
+                        const dataUrl = await domtoimage.toJpeg(billingCard, {
+                            quality: 1, // Chất lượng tối đa (0-1)
+                            scale: 2 // Tăng độ phân giải gấp 2 lần
+                        });
+                        const link = document.createElement("a");
+                        link.download = `hoa_don_${Date.now()}.${selectedFormat}`;
+                        link.href = dataUrl;
+                        link.click();
+                    } else if (selectedFormat === "pdf") {
+                        const dataUrl = await domtoimage.toPng(billingCard, {
+                            quality: 1, // Chất lượng tối đa
+                            scale: 2 // Tăng độ phân giải
+                        });
+                        const { jsPDF } = window.jspdf;
+                        const pdf = new jsPDF({
+                            orientation: 'portrait',
+                            unit: 'mm',
+                            format: 'a4'
+                        });
+                        const imgProps = pdf.getImageProperties(dataUrl);
+                        const pdfWidth = pdf.internal.pageSize.getWidth();
+                        const pdfHeight = (imgProps.height * pdfWidth) / imgProps.width;
+
+                        // Nếu nội dung quá dài, chia thành nhiều trang
+                        if (pdfHeight > pdf.internal.pageSize.getHeight()) {
+                            const ratio = pdf.internal.pageSize.getHeight() / pdfHeight;
+                            const adjustedHeight = pdfHeight * ratio;
+                            pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, adjustedHeight);
+                        } else {
+                            pdf.addImage(dataUrl, 'PNG', 0, 0, pdfWidth, pdfHeight);
+                        }
+                        pdf.save(`hoa_don_${Date.now()}.pdf`);
+                    }
+
+                    // Khôi phục lại style ban đầu
+                    billingCard.style.height = originalHeight;
+                    billingCard.style.overflow = originalOverflow;
+                } catch (error) {
+                    alert("Có lỗi xảy ra khi tạo file. Vui lòng thử lại.\nChi tiết lỗi: " + error.message);
+                    console.error(error);
+                }
+            });
+        }
+    };
+</script>
 
 
 </body>

--- a/Webike/src/main/webapp/GKY/product.jsp
+++ b/Webike/src/main/webapp/GKY/product.jsp
@@ -236,6 +236,20 @@
         }).showToast();
     }
 </script>
+<script>
+    <c:if test="${not empty sessionScope.cancelMessage}">
+    Toastify({
+        text: "${sessionScope.cancelMessage}",
+        duration: 2000,
+        gravity: "top",
+        position: "right",
+        backgroundColor: "#ff4444",
+        stopOnFocus: true
+    }).showToast();
+    // Xóa thông báo khỏi session để không hiển thị lại khi tải lại trang
+    <% session.removeAttribute("cancelMessage"); %>
+    </c:if>
+</script>
 <script src="${pageContext.request.contextPath}/GKY/assets/js/product.js"></script>
 <%--<script src="${pageContext.request.contextPath}/GKY/assets/js/FilterProductAjax.js"></script>--%>
 <script src="${pageContext.request.contextPath}/GKY/assets/bootstrap/js/bootstrap.bundle.min.js"></script>


### PR DESCRIPTION
- Người dùng chọn định dạng trước khi in (PNG hoặc PDF) sau đó chọn  "Xác nhận" file sẽ được lưu cục bộ về máy của người dùng
- Khi người dùng chọn huỷ thanh toán trong quá trình thanh toán thì sẽ hiện ra toast message thông báo và chuyển hướng người dùng về trang list-product